### PR TITLE
Enable auto-merge for patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "github>cy6erskunk/renovate-config",
-    "github>cy6erskunk/renovate-config:automerge-minor-patch-devdeps"
+    "github>cy6erskunk/renovate-config:automerge-minor-patch-devdeps",
+    "github>cy6erskunk/renovate-config:automerge-patch-deps"
   ]
 }


### PR DESCRIPTION
Currently, auto-merge is configured for patch- and minor-level updates of dev dependencies. It should be safe to enable auto-merge for patch-level updates of dependencies, given that build, tests, etc are green.